### PR TITLE
Add inventory lock option when the menu is opened

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -38,12 +38,21 @@ function MenuData.Open(type, namespace, name, data, submit, cancel, change, clos
 		FreezeEntityPosition(PlayerPedId(), true)
 	end
 
+	if menu.data.lockInventory then
+        LocalPlayer.state:set("inv_busy", true, true)
+    end
+
 	menu.close = function()
 		MenuData.RegisteredTypes[type].close(namespace, name)
 
 		if menu.data.disableMovement then
 			FreezeEntityPosition(PlayerPedId(), false)
 		end
+
+		if menu.data.lockInventory then
+            LocalPlayer.state:set("inv_busy", false, true)
+        end
+		
 
 		for i = 1, #MenuData.Opened, 1 do
 			if MenuData.Opened[i] then

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-menubase'
-version '1.1.2'
+version '1.1.3'
 
 client_scripts {
     'client/main.lua'


### PR DESCRIPTION
- Added a new parameter in client/main.lua to lock the inventory while a menu is open.
- Bumped the version number in fxmanifest.lua.

The feature is that you can lock inventory with a simple option.

**HOW TO USE**

You Just need to add lockInventory = true/false under title or aling!
Example:

```
local menu = MenuData.Open('default', GetCurrentResourceName(), 'teleport_menu',
    {
        title = 'Teleport Menu',
        align = 'top-left',
        lockInventory = true,
        elements = elements
    },
    function(data, menu)
        SetEntityCoords(PlayerPedId(), data.current.value.x, data.current.value.y, data.current.value.z, false, false, false, true)
        menu.close()
    end,
    function(data, menu)
        menu.close()
    end
```